### PR TITLE
feat: add Firestore-ready data models with serialization

### DIFF
--- a/PlantCarePulse/lib/models/care_activity.dart
+++ b/PlantCarePulse/lib/models/care_activity.dart
@@ -1,0 +1,88 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Care Activity Model
+/// Represents a care activity performed on a user's plant
+class CareActivity {
+  final String id;
+  final String activityType; // watering, fertilizing, pruning, repotting, observation
+  final DateTime performedAt;
+  final String? notes;
+  final String? amount;
+  final String? imageUrl;
+
+  CareActivity({
+    required this.id,
+    required this.activityType,
+    required this.performedAt,
+    this.notes,
+    this.amount,
+    this.imageUrl,
+  });
+
+  // Convert CareActivity to Map for Firestore
+  Map<String, dynamic> toMap() {
+    return {
+      'activityId': id,
+      'activityType': activityType,
+      'performedAt': Timestamp.fromDate(performedAt),
+      'notes': notes,
+      'amount': amount,
+      'imageUrl': imageUrl,
+      'createdAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  // Create CareActivity from Firestore document
+  factory CareActivity.fromMap(Map<String, dynamic> map, String documentId) {
+    return CareActivity(
+      id: documentId,
+      activityType: map['activityType'] ?? 'observation',
+      performedAt: (map['performedAt'] as Timestamp).toDate(),
+      notes: map['notes'],
+      amount: map['amount'],
+      imageUrl: map['imageUrl'],
+    );
+  }
+
+  // Create CareActivity from Firestore DocumentSnapshot
+  factory CareActivity.fromFirestore(DocumentSnapshot doc) {
+    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+    return CareActivity.fromMap(data, doc.id);
+  }
+
+  // Get icon for activity type
+  String get activityIcon {
+    switch (activityType) {
+      case 'watering':
+        return '💧';
+      case 'fertilizing':
+        return '🌱';
+      case 'pruning':
+        return '✂️';
+      case 'repotting':
+        return '🪴';
+      case 'observation':
+        return '👁️';
+      default:
+        return '📝';
+    }
+  }
+
+  // Get display name for activity type
+  String get activityDisplayName {
+    switch (activityType) {
+      case 'watering':
+        return 'Watering';
+      case 'fertilizing':
+        return 'Fertilizing';
+      case 'pruning':
+        return 'Pruning';
+      case 'repotting':
+        return 'Repotting';
+      case 'observation':
+        return 'Observation';
+      default:
+        return 'Activity';
+    }
+  }
+}

--- a/PlantCarePulse/lib/models/plant.dart
+++ b/PlantCarePulse/lib/models/plant.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class Plant {
   final String id;
   final String name;
@@ -22,6 +24,46 @@ class Plant {
     required this.description,
     required this.careTips,
   });
+
+  // Convert Plant to Map for Firestore
+  Map<String, dynamic> toMap() {
+    return {
+      'plantId': id,
+      'name': name,
+      'scientificName': scientificName,
+      'category': category,
+      'imageEmoji': imageEmoji,
+      'wateringFrequencyDays': wateringFrequencyDays,
+      'sunlight': sunlight,
+      'difficulty': difficulty,
+      'description': description,
+      'careTips': careTips,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  // Create Plant from Firestore document
+  factory Plant.fromMap(Map<String, dynamic> map, String documentId) {
+    return Plant(
+      id: documentId,
+      name: map['name'] ?? '',
+      scientificName: map['scientificName'] ?? '',
+      category: map['category'] ?? '',
+      imageEmoji: map['imageEmoji'] ?? '🌱',
+      wateringFrequencyDays: map['wateringFrequencyDays'] ?? 7,
+      sunlight: map['sunlight'] ?? '',
+      difficulty: map['difficulty'] ?? 'Medium',
+      description: map['description'] ?? '',
+      careTips: List<String>.from(map['careTips'] ?? []),
+    );
+  }
+
+  // Create Plant from Firestore DocumentSnapshot
+  factory Plant.fromFirestore(DocumentSnapshot doc) {
+    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+    return Plant.fromMap(data, doc.id);
+  }
 
   // Sample plant data
   static List<Plant> getSamplePlants() {

--- a/PlantCarePulse/lib/models/reminder.dart
+++ b/PlantCarePulse/lib/models/reminder.dart
@@ -1,0 +1,133 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Reminder Model
+/// Represents a scheduled care reminder for a user's plant
+class Reminder {
+  final String id;
+  final String userPlantId;
+  final String reminderType; // watering, fertilizing, pruning
+  final DateTime scheduledFor;
+  final bool isCompleted;
+  final DateTime? completedAt;
+  final bool isRecurring;
+  final int? recurringDays;
+
+  Reminder({
+    required this.id,
+    required this.userPlantId,
+    required this.reminderType,
+    required this.scheduledFor,
+    this.isCompleted = false,
+    this.completedAt,
+    this.isRecurring = false,
+    this.recurringDays,
+  });
+
+  // Convert Reminder to Map for Firestore
+  Map<String, dynamic> toMap() {
+    return {
+      'reminderId': id,
+      'userPlantId': userPlantId,
+      'reminderType': reminderType,
+      'scheduledFor': Timestamp.fromDate(scheduledFor),
+      'isCompleted': isCompleted,
+      'completedAt': completedAt != null ? Timestamp.fromDate(completedAt!) : null,
+      'isRecurring': isRecurring,
+      'recurringDays': recurringDays,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  // Create Reminder from Firestore document
+  factory Reminder.fromMap(Map<String, dynamic> map, String documentId) {
+    return Reminder(
+      id: documentId,
+      userPlantId: map['userPlantId'] ?? '',
+      reminderType: map['reminderType'] ?? 'watering',
+      scheduledFor: (map['scheduledFor'] as Timestamp).toDate(),
+      isCompleted: map['isCompleted'] ?? false,
+      completedAt: map['completedAt'] != null 
+          ? (map['completedAt'] as Timestamp).toDate() 
+          : null,
+      isRecurring: map['isRecurring'] ?? false,
+      recurringDays: map['recurringDays'],
+    );
+  }
+
+  // Create Reminder from Firestore DocumentSnapshot
+  factory Reminder.fromFirestore(DocumentSnapshot doc) {
+    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+    return Reminder.fromMap(data, doc.id);
+  }
+
+  // Check if reminder is overdue
+  bool get isOverdue {
+    return !isCompleted && scheduledFor.isBefore(DateTime.now());
+  }
+
+  // Check if reminder is due today
+  bool get isDueToday {
+    final now = DateTime.now();
+    return !isCompleted && 
+           scheduledFor.year == now.year &&
+           scheduledFor.month == now.month &&
+           scheduledFor.day == now.day;
+  }
+
+  // Get days until reminder
+  int get daysUntil {
+    return scheduledFor.difference(DateTime.now()).inDays;
+  }
+
+  // Get icon for reminder type
+  String get reminderIcon {
+    switch (reminderType) {
+      case 'watering':
+        return '💧';
+      case 'fertilizing':
+        return '🌱';
+      case 'pruning':
+        return '✂️';
+      default:
+        return '🔔';
+    }
+  }
+
+  // Get display name for reminder type
+  String get reminderDisplayName {
+    switch (reminderType) {
+      case 'watering':
+        return 'Water Plant';
+      case 'fertilizing':
+        return 'Fertilize Plant';
+      case 'pruning':
+        return 'Prune Plant';
+      default:
+        return 'Care Reminder';
+    }
+  }
+
+  // Create a copy with updated fields
+  Reminder copyWith({
+    String? id,
+    String? userPlantId,
+    String? reminderType,
+    DateTime? scheduledFor,
+    bool? isCompleted,
+    DateTime? completedAt,
+    bool? isRecurring,
+    int? recurringDays,
+  }) {
+    return Reminder(
+      id: id ?? this.id,
+      userPlantId: userPlantId ?? this.userPlantId,
+      reminderType: reminderType ?? this.reminderType,
+      scheduledFor: scheduledFor ?? this.scheduledFor,
+      isCompleted: isCompleted ?? this.isCompleted,
+      completedAt: completedAt ?? this.completedAt,
+      isRecurring: isRecurring ?? this.isRecurring,
+      recurringDays: recurringDays ?? this.recurringDays,
+    );
+  }
+}

--- a/PlantCarePulse/lib/models/user.dart
+++ b/PlantCarePulse/lib/models/user.dart
@@ -1,0 +1,141 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// User Model
+/// Represents a user profile in the application
+class UserModel {
+  final String userId;
+  final String name;
+  final String email;
+  final String? photoUrl;
+  final int plantCount;
+  final int daysActive;
+  final UserPreferences preferences;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? lastLoginAt;
+
+  UserModel({
+    required this.userId,
+    required this.name,
+    required this.email,
+    this.photoUrl,
+    this.plantCount = 0,
+    this.daysActive = 0,
+    required this.preferences,
+    required this.createdAt,
+    required this.updatedAt,
+    this.lastLoginAt,
+  });
+
+  // Convert User to Map for Firestore
+  Map<String, dynamic> toMap() {
+    return {
+      'userId': userId,
+      'name': name,
+      'email': email,
+      'photoUrl': photoUrl,
+      'plantCount': plantCount,
+      'daysActive': daysActive,
+      'preferences': preferences.toMap(),
+      'createdAt': Timestamp.fromDate(createdAt),
+      'updatedAt': Timestamp.fromDate(updatedAt),
+      'lastLoginAt': lastLoginAt != null ? Timestamp.fromDate(lastLoginAt!) : null,
+    };
+  }
+
+  // Create User from Firestore document
+  factory UserModel.fromMap(Map<String, dynamic> map, String documentId) {
+    return UserModel(
+      userId: documentId,
+      name: map['name'] ?? '',
+      email: map['email'] ?? '',
+      photoUrl: map['photoUrl'],
+      plantCount: map['plantCount'] ?? 0,
+      daysActive: map['daysActive'] ?? 0,
+      preferences: UserPreferences.fromMap(map['preferences'] ?? {}),
+      createdAt: (map['createdAt'] as Timestamp).toDate(),
+      updatedAt: (map['updatedAt'] as Timestamp).toDate(),
+      lastLoginAt: map['lastLoginAt'] != null 
+          ? (map['lastLoginAt'] as Timestamp).toDate() 
+          : null,
+    );
+  }
+
+  // Create User from Firestore DocumentSnapshot
+  factory UserModel.fromFirestore(DocumentSnapshot doc) {
+    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+    return UserModel.fromMap(data, doc.id);
+  }
+
+  // Create a copy with updated fields
+  UserModel copyWith({
+    String? userId,
+    String? name,
+    String? email,
+    String? photoUrl,
+    int? plantCount,
+    int? daysActive,
+    UserPreferences? preferences,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    DateTime? lastLoginAt,
+  }) {
+    return UserModel(
+      userId: userId ?? this.userId,
+      name: name ?? this.name,
+      email: email ?? this.email,
+      photoUrl: photoUrl ?? this.photoUrl,
+      plantCount: plantCount ?? this.plantCount,
+      daysActive: daysActive ?? this.daysActive,
+      preferences: preferences ?? this.preferences,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      lastLoginAt: lastLoginAt ?? this.lastLoginAt,
+    );
+  }
+}
+
+/// User Preferences Model
+/// Represents user preferences and settings
+class UserPreferences {
+  final bool notificationsEnabled;
+  final String reminderTime; // HH:mm format
+  final String theme; // light/dark
+
+  UserPreferences({
+    this.notificationsEnabled = true,
+    this.reminderTime = '09:00',
+    this.theme = 'light',
+  });
+
+  // Convert UserPreferences to Map
+  Map<String, dynamic> toMap() {
+    return {
+      'notificationsEnabled': notificationsEnabled,
+      'reminderTime': reminderTime,
+      'theme': theme,
+    };
+  }
+
+  // Create UserPreferences from Map
+  factory UserPreferences.fromMap(Map<String, dynamic> map) {
+    return UserPreferences(
+      notificationsEnabled: map['notificationsEnabled'] ?? true,
+      reminderTime: map['reminderTime'] ?? '09:00',
+      theme: map['theme'] ?? 'light',
+    );
+  }
+
+  // Create a copy with updated fields
+  UserPreferences copyWith({
+    bool? notificationsEnabled,
+    String? reminderTime,
+    String? theme,
+  }) {
+    return UserPreferences(
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+      reminderTime: reminderTime ?? this.reminderTime,
+      theme: theme ?? this.theme,
+    );
+  }
+}

--- a/PlantCarePulse/lib/models/user_plant.dart
+++ b/PlantCarePulse/lib/models/user_plant.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'plant.dart';
 
 class UserPlant {
@@ -42,5 +43,45 @@ class UserPlant {
 
   void water() {
     lastWatered = DateTime.now();
+  }
+
+  // Convert UserPlant to Map for Firestore
+  Map<String, dynamic> toMap() {
+    return {
+      'userPlantId': id,
+      'plantId': plant.id,
+      'nickname': nickname,
+      'location': location,
+      'dateAdded': Timestamp.fromDate(dateAdded),
+      'lastWatered': lastWatered != null ? Timestamp.fromDate(lastWatered!) : null,
+      'nextWateringDate': Timestamp.fromDate(nextWateringDate),
+      'wateringFrequencyDays': plant.wateringFrequencyDays,
+      'healthStatus': needsWatering ? 'warning' : 'healthy',
+      'notes': notes,
+      'isActive': true,
+      'createdAt': FieldValue.serverTimestamp(),
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+  }
+
+  // Create UserPlant from Firestore document
+  factory UserPlant.fromMap(Map<String, dynamic> map, Plant plant, String documentId) {
+    return UserPlant(
+      id: documentId,
+      plant: plant,
+      nickname: map['nickname'] ?? '',
+      location: map['location'] ?? '',
+      dateAdded: (map['dateAdded'] as Timestamp).toDate(),
+      lastWatered: map['lastWatered'] != null 
+          ? (map['lastWatered'] as Timestamp).toDate() 
+          : null,
+      notes: map['notes'] ?? '',
+    );
+  }
+
+  // Create UserPlant from Firestore DocumentSnapshot
+  factory UserPlant.fromFirestore(DocumentSnapshot doc, Plant plant) {
+    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+    return UserPlant.fromMap(data, plant, doc.id);
   }
 }


### PR DESCRIPTION
- Updated Plant model with toMap() and fromFirestore() methods
- Updated UserPlant model with Firestore serialization
- Added CareActivity model for tracking plant care history
- Added Reminder model for scheduled care reminders
- Added User model with UserPreferences for user profiles
- All models include Firestore Timestamp conversion
- Added helper methods for display and status checks
- Models aligned with Firestore schema design